### PR TITLE
Use the association's 'as' property when creating with relations

### DIFF
--- a/src/sequelize/associations/index.ts
+++ b/src/sequelize/associations/index.ts
@@ -16,7 +16,11 @@ import {
 export const getValidAttributesAndAssociations = (
   attributes: Attributes<any> | Array<Attributes<any>>,
   associations: Record<string, IAssociation> | undefined,
-) => {
+): {
+  externalAssociations: string[];
+  otherAssociationAttributes: JSONAnyObject;
+  currentModelAttributes: Attributes<any>;
+} => {
   const externalAssociations: string[] = [];
   let currentModelAttributes = attributes;
   const otherAssociationAttributes: JSONAnyObject = {};
@@ -67,10 +71,7 @@ export const handleCreateAssociations = async (
   primaryKey = "id",
 ): Promise<void> => {
   for (const association of validAssociations) {
-    const associationDetails = {
-      ...associations[association],
-      as: association,
-    };
+    const associationDetails = associations[association];
     const associationAttribute = attributes[association];
 
     switch (associationDetails.type) {

--- a/src/sequelize/associations/sequelize.patch.ts
+++ b/src/sequelize/associations/sequelize.patch.ts
@@ -5,7 +5,6 @@ import type { Sequelize, Transaction } from "sequelize";
 import { NotFoundError } from "../types";
 import type { IAssociationBody } from "../types";
 import { camelCaseToPascalCase } from "../util/camelCaseToPascalCase";
-import { pascalCaseToCamelCase } from "../util/pascalCaseToCamelCase";
 
 export const handleUpdateOne = async (
   sequelize: Sequelize,
@@ -35,9 +34,7 @@ export const handleUpdateOne = async (
     throw [
       new NotFoundError({
         detail: `Payload must include an ID of an existing '${modelName}'.`,
-        pointer: `/data/relationships/${
-          as ?? pascalCaseToCamelCase(modelName)
-        }/data/id`,
+        pointer: `/data/relationships/${as}/data/id`,
       }),
     ];
   }
@@ -86,7 +83,7 @@ export const handleUpdateMany = async (
               new NotFoundError({
                 detail: `Payload must include an ID of an existing '${modelName}'.`,
                 pointer: `/data/relationships/${pluralize(
-                  as ?? pascalCaseToCamelCase(modelName),
+                  as,
                 )}/data/${index}/id`,
               }),
             ],

--- a/src/sequelize/associations/sequelize.post.ts
+++ b/src/sequelize/associations/sequelize.post.ts
@@ -1,7 +1,7 @@
 import type { Sequelize, Transaction } from "sequelize";
 import { NotFoundError } from "../types";
 import type { IAssociationBody, JSONAnyObject } from "../types";
-import { pluralize } from "inflection";
+import { classify, pluralize } from "inflection";
 import { camelCaseToPascalCase } from "../util/camelCaseToPascalCase";
 import { pascalCaseToCamelCase } from "../util/pascalCaseToCamelCase";
 
@@ -128,6 +128,7 @@ export const handleCreateMany = async (
   }
 
   const modelName = association.details.model;
+  const addFnName = `add${classify(association.details.as)}`;
 
   const results = await Promise.allSettled(
     association.attributes.map(async (attribute, index) => {
@@ -135,7 +136,7 @@ export const handleCreateMany = async (
 
       if (isCreate) {
         const id = (
-          await sequelize.models[association.details.model].create(
+          await sequelize.models[modelName].create(
             { ...attribute, through: undefined },
             { transaction },
           )
@@ -143,7 +144,7 @@ export const handleCreateMany = async (
           .getDataValue(primaryKey)
           .toString();
 
-        return modelInstance[`add${modelName}`](id, {
+        return modelInstance[addFnName](id, {
           through: attribute.through,
           transaction,
         });
@@ -160,7 +161,7 @@ export const handleCreateMany = async (
         });
       }
 
-      return modelInstance[`add${modelName}`](attribute[primaryKey], {
+      return modelInstance[addFnName](attribute[primaryKey], {
         through: attribute.through,
         transaction,
       });

--- a/src/sequelize/associations/sequelize.post.ts
+++ b/src/sequelize/associations/sequelize.post.ts
@@ -4,7 +4,6 @@ import type { IAssociationBody, JSONAnyObject } from "../types";
 import { pluralize } from "inflection";
 import { camelCaseToPascalCase } from "../util/camelCaseToPascalCase";
 import { pascalCaseToCamelCase } from "../util/pascalCaseToCamelCase";
-import { addTicks } from "sequelize/types/utils";
 
 export const handleCreateHasOne = async (
   sequelize: Sequelize,

--- a/src/sequelize/associations/sequelize.post.ts
+++ b/src/sequelize/associations/sequelize.post.ts
@@ -3,7 +3,6 @@ import { NotFoundError } from "../types";
 import type { IAssociationBody, JSONAnyObject } from "../types";
 import { pluralize } from "inflection";
 import { camelCaseToPascalCase } from "../util/camelCaseToPascalCase";
-import { pascalCaseToCamelCase } from "../util/pascalCaseToCamelCase";
 
 export const handleCreateHasOne = async (
   sequelize: Sequelize,
@@ -39,9 +38,7 @@ export const handleCreateHasOne = async (
       throw [
         new NotFoundError({
           detail: `Payload must include an ID of an existing '${modelName}'.`,
-          pointer: `/data/relationships/${
-            as ?? pascalCaseToCamelCase(modelName)
-          }/data/id`,
+          pointer: `/data/relationships/${as}/data/id`,
         }),
       ];
     }

--- a/src/sequelize/util/pascalCaseToCamelCase.ts
+++ b/src/sequelize/util/pascalCaseToCamelCase.ts
@@ -1,5 +1,0 @@
-export function pascalCaseToCamelCase(pascalCaseString: string): string {
-  return typeof pascalCaseString !== "string"
-    ? pascalCaseString
-    : pascalCaseString.charAt(0).toLowerCase() + pascalCaseString.slice(1);
-}

--- a/tests/bulk_create.spec.ts
+++ b/tests/bulk_create.spec.ts
@@ -307,7 +307,7 @@ describe("Bulk Create", () => {
     );
 
     User.hasMany(Skill, {
-      as: "skills",
+      as: "associatedSkills",
       foreignKey: "userId",
     });
 
@@ -324,34 +324,34 @@ describe("Bulk Create", () => {
       {
         name: "Justin",
         age: 33,
-        skills: [{ name: "Programming" }, { id: cookingId }],
+        associatedSkills: [{ name: "Programming" }, { id: cookingId }],
       },
       {
         name: "Kevin",
         age: 32,
-        skills: [{ name: "Running" }],
+        associatedSkills: [{ name: "Running" }],
       },
     ]);
 
     const usersWithAssociations = await User.findAll({
       where: { id: { [Op.in]: users.map((user) => user.id) } },
-      include: "skills",
+      include: "associatedSkills",
     });
 
     expect(usersWithAssociations[0].name).toEqual("Justin");
     expect(usersWithAssociations[0].age).toEqual(33);
-    expect(usersWithAssociations[0].skills).toHaveLength(2);
+    expect(usersWithAssociations[0].associatedSkills).toHaveLength(2);
     expect(usersWithAssociations[1].name).toEqual("Kevin");
     expect(usersWithAssociations[1].age).toEqual(32);
-    expect(usersWithAssociations[1].skills).toHaveLength(1);
+    expect(usersWithAssociations[1].associatedSkills).toHaveLength(1);
 
-    const programming = usersWithAssociations[0].skills?.find(
+    const programming = usersWithAssociations[0].associatedSkills?.find(
       ({ name }) => name === "Programming",
     );
-    const cooking = usersWithAssociations[0].skills?.find(
+    const cooking = usersWithAssociations[0].associatedSkills?.find(
       ({ name }) => name === "Cooking",
     );
-    const running = usersWithAssociations[1].skills?.find(
+    const running = usersWithAssociations[1].associatedSkills?.find(
       ({ name }) => name === "Running",
     );
 
@@ -360,7 +360,7 @@ describe("Bulk Create", () => {
     expect(running).toBeTruthy();
 
     const programmingWithUser = await Skill.findByPk(
-      usersWithAssociations[0].skills?.find(
+      usersWithAssociations[0].associatedSkills?.find(
         ({ name }) => name === "Programming",
       )?.id,
       { include: ["user"] },
@@ -372,7 +372,7 @@ describe("Bulk Create", () => {
     expect(programmingWithUser?.user?.age).toEqual(33);
 
     const cookingWithUsers = await Skill.findByPk(
-      usersWithAssociations[0].skills?.find(({ name }) => name === "Cooking")
+      usersWithAssociations[0].associatedSkills?.find(({ name }) => name === "Cooking")
         ?.id,
       { include: ["user"] },
     );
@@ -383,7 +383,7 @@ describe("Bulk Create", () => {
     expect(cookingWithUsers?.user?.age).toEqual(33);
 
     const runningWithUser = await Skill.findByPk(
-      usersWithAssociations[1].skills?.find(({ name }) => name === "Running")
+      usersWithAssociations[1].associatedSkills?.find(({ name }) => name === "Running")
         ?.id,
       { include: ["user"] },
     );

--- a/tests/bulk_create.spec.ts
+++ b/tests/bulk_create.spec.ts
@@ -372,8 +372,9 @@ describe("Bulk Create", () => {
     expect(programmingWithUser?.user?.age).toEqual(33);
 
     const cookingWithUsers = await Skill.findByPk(
-      usersWithAssociations[0].associatedSkills?.find(({ name }) => name === "Cooking")
-        ?.id,
+      usersWithAssociations[0].associatedSkills?.find(
+        ({ name }) => name === "Cooking",
+      )?.id,
       { include: ["user"] },
     );
 
@@ -383,8 +384,9 @@ describe("Bulk Create", () => {
     expect(cookingWithUsers?.user?.age).toEqual(33);
 
     const runningWithUser = await Skill.findByPk(
-      usersWithAssociations[1].associatedSkills?.find(({ name }) => name === "Running")
-        ?.id,
+      usersWithAssociations[1].associatedSkills?.find(
+        ({ name }) => name === "Running",
+      )?.id,
       { include: ["user"] },
     );
 

--- a/tests/create.spec.ts
+++ b/tests/create.spec.ts
@@ -502,7 +502,7 @@ describe("Create", () => {
     );
 
     User.belongsToMany(Skill, {
-      as: "skills",
+      as: "associatedSkills",
       foreignKey: "userId",
       through: UserSkill,
     });
@@ -518,24 +518,24 @@ describe("Create", () => {
     const user = await User.create({
       name: "Justin",
       age: 33,
-      skills: [
+      associatedSkills: [
         { name: "Programming" },
         { name: "Cooking", through: { selfGranted: true } },
       ],
     });
 
     const userWithAssociations = await User.findByPk(user.id, {
-      include: "skills",
+      include: "associatedSkills",
     });
 
     expect(userWithAssociations?.name).toEqual("Justin");
     expect(userWithAssociations?.age).toEqual(33);
-    expect(userWithAssociations?.skills).toHaveLength(2);
+    expect(userWithAssociations?.associatedSkills).toHaveLength(2);
 
-    const programming = userWithAssociations?.skills?.find(
+    const programming = userWithAssociations?.associatedSkills?.find(
       ({ name }) => name === "Programming",
     );
-    const cooking = userWithAssociations?.skills?.find(
+    const cooking = userWithAssociations?.associatedSkills?.find(
       ({ name }) => name === "Cooking",
     );
 
@@ -543,8 +543,9 @@ describe("Create", () => {
     expect(cooking?.UserSkill?.selfGranted).toEqual(true);
 
     const programmingWithUser = await Skill.findByPk(
-      userWithAssociations?.skills?.find(({ name }) => name === "Programming")
-        ?.id,
+      userWithAssociations?.associatedSkills?.find(
+        ({ name }) => name === "Programming",
+      )?.id,
       { include: ["users"] },
     );
 
@@ -555,7 +556,9 @@ describe("Create", () => {
     expect(programmingWithUser?.users?.[0]?.UserSkill?.selfGranted).toBeNull();
 
     const cookingWithUser = await Skill.findByPk(
-      userWithAssociations?.skills?.find(({ name }) => name === "Cooking")?.id,
+      userWithAssociations?.associatedSkills?.find(
+        ({ name }) => name === "Cooking",
+      )?.id,
       { include: ["users"] },
     );
 

--- a/tests/extended.spec.ts
+++ b/tests/extended.spec.ts
@@ -77,9 +77,12 @@ describe("Extended", () => {
             type: "HasOne",
             key: "userId",
             model: "Skill",
+            as: "skill",
           },
         },
-        Skill: { user: { type: "BelongsTo", key: "userId", model: "User" } },
+        Skill: {
+          user: { type: "BelongsTo", key: "userId", model: "User", as: "user" },
+        },
       });
     });
 
@@ -123,8 +126,17 @@ describe("Extended", () => {
       });
 
       expect(getLookup(sequelize)).toEqual({
-        User: { skills: { type: "HasMany", key: "userId", model: "Skill" } },
-        Skill: { user: { type: "BelongsTo", key: "userId", model: "User" } },
+        User: {
+          skills: {
+            type: "HasMany",
+            key: "userId",
+            model: "Skill",
+            as: "skills",
+          },
+        },
+        Skill: {
+          user: { type: "BelongsTo", key: "userId", model: "User", as: "user" },
+        },
       });
     });
 
@@ -190,6 +202,7 @@ describe("Extended", () => {
             key: "skillId",
             model: "User",
             type: "BelongsToMany",
+            as: "users",
           },
         },
         User: {
@@ -198,6 +211,7 @@ describe("Extended", () => {
             key: "userId",
             model: "Skill",
             type: "BelongsToMany",
+            as: "skills",
           },
         },
         UserSkill: {},

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -28,6 +28,7 @@ export interface UserModel
   name: string;
   age: number;
   skills?: Array<Partial<SkillModel>>;
+  associatedSkills?: Array<Partial<SkillModel>>;
   UserSkill?: { selfGranted: boolean };
   through?: { selfGranted: boolean };
 }

--- a/tests/update.spec.ts
+++ b/tests/update.spec.ts
@@ -366,17 +366,17 @@ describe("Update", () => {
       { where: { id: user.id } },
     );
 
-    const updatedUser = await User.findByPk(user.id, { include: ["associatedSkills"] });
+    const updatedUser = await User.findByPk(user.id, {
+      include: ["associatedSkills"],
+    });
     const associatedSkills = await Skill.findAll();
 
     expect(updatedUser).toEqual(
       expect.objectContaining({ name: "Kevin", age: 32 }),
     );
-    expect(updatedUser?.associatedSkills?.map((skill) => skill.name).sort()).toEqual([
-      "Cooking",
-      "Programming",
-      "Running",
-    ]);
+    expect(
+      updatedUser?.associatedSkills?.map((skill) => skill.name).sort(),
+    ).toEqual(["Cooking", "Programming", "Running"]);
     expect(associatedSkills).toHaveLength(4);
   });
 

--- a/tests/update.spec.ts
+++ b/tests/update.spec.ts
@@ -320,7 +320,7 @@ describe("Update", () => {
     );
 
     User.hasMany(Skill, {
-      as: "skills",
+      as: "associatedSkills",
       foreignKey: "userId",
     });
 
@@ -334,7 +334,7 @@ describe("Update", () => {
     const user = await User.create({
       name: "Justin",
       age: 33,
-      skills: [
+      associatedSkills: [
         { name: "Acting" },
         { name: "Cooking" },
         { name: "Programming" },
@@ -357,7 +357,7 @@ describe("Update", () => {
       {
         name: "Kevin",
         age: 32,
-        skills: [
+        associatedSkills: [
           { id: cooking?.id },
           { id: programming?.id },
           { id: running?.id },
@@ -366,18 +366,18 @@ describe("Update", () => {
       { where: { id: user.id } },
     );
 
-    const updatedUser = await User.findByPk(user.id, { include: ["skills"] });
-    const skills = await Skill.findAll();
+    const updatedUser = await User.findByPk(user.id, { include: ["associatedSkills"] });
+    const associatedSkills = await Skill.findAll();
 
     expect(updatedUser).toEqual(
       expect.objectContaining({ name: "Kevin", age: 32 }),
     );
-    expect(updatedUser?.skills?.map((skill) => skill.name).sort()).toEqual([
+    expect(updatedUser?.associatedSkills?.map((skill) => skill.name).sort()).toEqual([
       "Cooking",
       "Programming",
       "Running",
     ]);
-    expect(skills).toHaveLength(4);
+    expect(associatedSkills).toHaveLength(4);
   });
 
   it("Should update records associated through hasMany - inverse", async () => {


### PR DESCRIPTION
Previously, the `as` property was only being set for handling associations in the non-bulk create case, and was not considered when finding the correct `add` function on the model instance in the create cases.  This PR addresses the problem in the following ways:
* When an association has an alias like `fooBar`, use the name `addFooBar` in create and bulk create to find the correct method name for creating a join entry from the model instance.
* Always set `as` when deriving the needed association properties from the Sequelize association, for all create and update cases -- this was part of the type definition anyway.