### PR TITLE
Support non-default and differing primary key fields.

### DIFF
--- a/src/sequelize/associations/index.ts
+++ b/src/sequelize/associations/index.ts
@@ -68,7 +68,6 @@ export const handleCreateAssociations = async (
   attributes: Attributes<any>,
   transaction: Transaction,
   modelId: string,
-  primaryKey = "id",
 ): Promise<void> => {
   for (const association of validAssociations) {
     const associationDetails = associations[association];
@@ -85,7 +84,6 @@ export const handleCreateAssociations = async (
           },
           { name: model.name, id: modelId },
           transaction,
-          primaryKey,
         );
         break;
       case "BelongsToMany":
@@ -98,7 +96,6 @@ export const handleCreateAssociations = async (
           },
           { name: model.name, id: modelId },
           transaction,
-          primaryKey,
         );
         break;
       default:
@@ -115,7 +112,6 @@ export const handleBulkCreateAssociations = async (
   attributes: JSONAnyObject,
   transaction: Transaction,
   modelIds: string[],
-  primaryKey = "id",
 ): Promise<void> => {
   for (const association of validAssociations) {
     const associationDetails = associations[association];
@@ -132,7 +128,6 @@ export const handleBulkCreateAssociations = async (
           },
           { name: model.name, id: modelIds },
           transaction,
-          primaryKey,
         );
         break;
       case "BelongsToMany":
@@ -145,7 +140,6 @@ export const handleBulkCreateAssociations = async (
           },
           { name: model.name, id: modelIds },
           transaction,
-          primaryKey,
         );
         break;
       default:
@@ -162,7 +156,6 @@ export const handleUpdateAssociations = async (
   attributes: Attributes<any>,
   transaction: Transaction,
   modelId: string,
-  primaryKey = "id",
 ): Promise<void> => {
   for (const association of validAssociations) {
     const associationDetails = associations[association];
@@ -182,7 +175,6 @@ export const handleUpdateAssociations = async (
             id: modelId,
           },
           transaction,
-          primaryKey,
         );
         break;
       case "HasMany":
@@ -198,7 +190,6 @@ export const handleUpdateAssociations = async (
             id: modelId,
           },
           transaction,
-          primaryKey,
         );
         break;
       default:

--- a/src/sequelize/associations/sequelize.post.ts
+++ b/src/sequelize/associations/sequelize.post.ts
@@ -113,12 +113,9 @@ export const handleCreateMany = async (
   transaction: Transaction,
   primaryKey = "id",
 ): Promise<void> => {
-  const modelInstance = await sequelize.models[model.name].findByPk(
-    model[primaryKey],
-    {
-      transaction,
-    },
-  );
+  const modelInstance = await sequelize.models[model.name].findByPk(model.id, {
+    transaction,
+  });
 
   if (!modelInstance) {
     throw [new Error("Unable to find created model")];
@@ -148,7 +145,9 @@ export const handleCreateMany = async (
       }
 
       if (
-        !(await sequelize.models[modelName].findByPk(attribute[primaryKey]))
+        !(await sequelize.models[modelName].findByPk(attribute[primaryKey], {
+          transaction,
+        }))
       ) {
         throw new NotFoundError({
           detail: `Payload must include an ID of an existing '${modelName}'.`,
@@ -193,7 +192,6 @@ export const handleBulkCreateMany = async (
     throw [new Error("Not all models were successfully created")];
   }
 
-  console.log("association details:", JSON.stringify(association.details));
   const modelName = association.details.model;
   const addFnName = `add${camelCaseToPascalCase(association.details.as)}`;
 

--- a/src/sequelize/associations/sequelize.post.ts
+++ b/src/sequelize/associations/sequelize.post.ts
@@ -9,42 +9,40 @@ export const handleCreateHasOne = async (
   association: IAssociationBody<JSONAnyObject>,
   model: { name: string; id: string },
   transaction: Transaction,
-  primaryKey = "id",
 ): Promise<void> => {
-  const { model: modelName, as } = association.details;
-  const modelInstance = await sequelize.models[model.name].findByPk(
-    model[primaryKey],
-    {
-      transaction,
-    },
-  );
+  const { model: associatedModelName, as } = association.details;
+  const modelInstance = await sequelize.models[model.name].findByPk(model.id, {
+    transaction,
+  });
   if (!modelInstance) {
     throw [new Error("Unable to find created model")];
   }
   let joinId: string | undefined;
-  const isCreate = !association.attributes[primaryKey];
+  const associatedModelPrimaryKey =
+    sequelize.models[association.details.model].primaryKeyAttribute;
+  const isCreate = !association.attributes[associatedModelPrimaryKey];
   if (isCreate) {
-    const model = await sequelize.models[modelName].create(
+    const model = await sequelize.models[associatedModelName].create(
       association.attributes,
       {
         transaction,
       },
     );
-    joinId = model[primaryKey];
+    joinId = model[associatedModelPrimaryKey];
   } else {
-    joinId = association.attributes[primaryKey];
+    joinId = association.attributes[associatedModelPrimaryKey];
 
-    if (!(await sequelize.models[modelName].findByPk(joinId))) {
+    if (!(await sequelize.models[associatedModelName].findByPk(joinId))) {
       throw [
         new NotFoundError({
-          detail: `Payload must include an ID of an existing '${modelName}'.`,
+          detail: `Payload must include an ID of an existing '${associatedModelName}'.`,
           pointer: `/data/relationships/${as}/data/id`,
         }),
       ];
     }
   }
 
-  const setter = `set${as ? camelCaseToPascalCase(as) : modelName}`;
+  const setter = `set${as ? camelCaseToPascalCase(as) : associatedModelName}`;
   await modelInstance[setter](joinId, {
     transaction,
   });
@@ -55,11 +53,12 @@ export const handleBulkCreateHasOne = async (
   association: IAssociationBody<JSONAnyObject[]>,
   model: { name: string; id: string[] },
   transaction: Transaction,
-  primaryKey = "id",
 ): Promise<void> => {
+  const baseModelPrimaryKey = sequelize.models[model.name].primaryKeyAttribute;
+
   const modelInstances = await sequelize.models[model.name].findAll({
     where: {
-      [primaryKey]: model.id,
+      [baseModelPrimaryKey]: model.id,
     },
     transaction,
   });
@@ -68,40 +67,47 @@ export const handleBulkCreateHasOne = async (
     throw [new Error("Not all models were successfully created")];
   }
 
-  const modelName = association.details.model;
+  const associatedModelName = association.details.model;
+  const associatedModelPrimaryKey =
+    sequelize.models[association.details.model].primaryKeyAttribute;
 
   await Promise.all(
     association.attributes.map(async (attribute, index) => {
-      const isCreate = !attribute[primaryKey];
+      const isCreate = !attribute[associatedModelPrimaryKey];
 
       if (isCreate) {
         const id = (
-          await sequelize.models[modelName].create(attribute, {
+          await sequelize.models[associatedModelName].create(attribute, {
             transaction,
           })
         )
-          .getDataValue(primaryKey)
+          .getDataValue(associatedModelPrimaryKey)
           .toString();
 
-        return modelInstances[index][`set${modelName}`](id, {
+        return modelInstances[index][`set${associatedModelName}`](id, {
           transaction,
         });
       }
 
       if (
-        !(await sequelize.models[modelName].findByPk(attribute[primaryKey]))
+        !(await sequelize.models[associatedModelName].findByPk(
+          attribute[associatedModelPrimaryKey],
+        ))
       ) {
         throw [
           new NotFoundError({
-            detail: `Payload must include an ID of an existing '${modelName}'.`,
-            pointer: `/data/${index}/relationships/${modelName.toLowerCase()}/data/id`,
+            detail: `Payload must include an ID of an existing '${associatedModelName}'.`,
+            pointer: `/data/${index}/relationships/${associatedModelName.toLowerCase()}/data/id`,
           }),
         ];
       }
 
-      return modelInstances[index][`set${modelName}`](attribute[primaryKey], {
-        transaction,
-      });
+      return modelInstances[index][`set${associatedModelName}`](
+        attribute[associatedModelPrimaryKey],
+        {
+          transaction,
+        },
+      );
     }),
   );
 };
@@ -111,7 +117,6 @@ export const handleCreateMany = async (
   association: IAssociationBody<JSONAnyObject[]>,
   model: { name: string; id: string },
   transaction: Transaction,
-  primaryKey = "id",
 ): Promise<void> => {
   const modelInstance = await sequelize.models[model.name].findByPk(model.id, {
     transaction,
@@ -121,21 +126,23 @@ export const handleCreateMany = async (
     throw [new Error("Unable to find created model")];
   }
 
-  const modelName = association.details.model;
+  const associatedModelName = association.details.model;
+  const associatedModelPrimaryKey =
+    sequelize.models[associatedModelName].primaryKeyAttribute;
   const addFnName = `add${camelCaseToPascalCase(association.details.as)}`;
 
   const results = await Promise.allSettled(
     association.attributes.map(async (attribute, index) => {
-      const isCreate = !attribute[primaryKey];
+      const isCreate = !attribute[associatedModelPrimaryKey];
 
       if (isCreate) {
         const id = (
-          await sequelize.models[modelName].create(
+          await sequelize.models[associatedModelName].create(
             { ...attribute, through: undefined },
             { transaction },
           )
         )
-          .getDataValue(primaryKey)
+          .getDataValue(associatedModelPrimaryKey)
           .toString();
 
         return modelInstance[addFnName](id, {
@@ -145,19 +152,22 @@ export const handleCreateMany = async (
       }
 
       if (
-        !(await sequelize.models[modelName].findByPk(attribute[primaryKey], {
-          transaction,
-        }))
+        !(await sequelize.models[associatedModelName].findByPk(
+          attribute[associatedModelPrimaryKey],
+          {
+            transaction,
+          },
+        ))
       ) {
         throw new NotFoundError({
-          detail: `Payload must include an ID of an existing '${modelName}'.`,
+          detail: `Payload must include an ID of an existing '${associatedModelName}'.`,
           pointer: `/data/relationships/${pluralize(
-            modelName.toLowerCase(),
+            associatedModelName.toLowerCase(),
           )}/data/${index}/id`,
         });
       }
 
-      return modelInstance[addFnName](attribute[primaryKey], {
+      return modelInstance[addFnName](attribute[associatedModelPrimaryKey], {
         through: attribute.through,
         transaction,
       });
@@ -178,12 +188,12 @@ export const handleBulkCreateMany = async (
   association: IAssociationBody<JSONAnyObject[][]>,
   model: { name: string; id: string[] },
   transaction: Transaction,
-  primaryKey = "id",
 ): Promise<void> => {
+  const baseModelPrimaryKey = sequelize.models[model.name].primaryKeyAttribute;
   // Create an instance of the model using the id
   const modelInstances = await sequelize.models[model.name].findAll({
     where: {
-      [primaryKey]: model.id,
+      [baseModelPrimaryKey]: model.id,
     },
     transaction,
   });
@@ -192,24 +202,26 @@ export const handleBulkCreateMany = async (
     throw [new Error("Not all models were successfully created")];
   }
 
-  const modelName = association.details.model;
+  const associatedModelName = association.details.model;
+  const associatedModelPrimaryKey =
+    sequelize.models[associatedModelName].primaryKeyAttribute;
   const addFnName = `add${camelCaseToPascalCase(association.details.as)}`;
 
   const results = await Promise.all(
     association.attributes.map(async (attributes, index) => {
       return Promise.allSettled(
         attributes.map(async (attribute, index2) => {
-          const isCreate = !attribute[primaryKey];
+          const isCreate = !attribute[associatedModelPrimaryKey];
 
           if (isCreate) {
             // Create the models first and add their ids to the joinIds.
             const id = (
-              await sequelize.models[modelName].create(
+              await sequelize.models[associatedModelName].create(
                 { ...attribute, through: undefined },
                 { transaction },
               )
             )
-              .getDataValue(primaryKey)
+              .getDataValue(associatedModelPrimaryKey)
               .toString();
 
             return modelInstances[index][addFnName](id, {
@@ -219,20 +231,25 @@ export const handleBulkCreateMany = async (
           }
 
           if (
-            !(await sequelize.models[modelName].findByPk(attribute[primaryKey]))
+            !(await sequelize.models[associatedModelName].findByPk(
+              attribute[associatedModelPrimaryKey],
+            ))
           ) {
             throw new NotFoundError({
-              detail: `Payload must include an ID of an existing '${modelName}'.`,
+              detail: `Payload must include an ID of an existing '${associatedModelName}'.`,
               pointer: `/data/${index}/relationships/${pluralize(
-                modelName.toLowerCase(),
+                associatedModelName.toLowerCase(),
               )}/data/${index2}/id`,
             });
           }
 
-          return modelInstances[index][addFnName](attribute[primaryKey], {
-            through: attribute.through,
-            transaction,
-          });
+          return modelInstances[index][addFnName](
+            attribute[associatedModelPrimaryKey],
+            {
+              through: attribute.through,
+              transaction,
+            },
+          );
         }),
       );
     }),

--- a/src/sequelize/extended.ts
+++ b/src/sequelize/extended.ts
@@ -106,7 +106,6 @@ export const extendSequelize = (SequelizeClass: any) => {
         attributes,
         transaction,
         modelData?.[modelPrimaryKey],
-        modelPrimaryKey,
       );
 
       !options?.transaction && (await transaction.commit());
@@ -172,7 +171,6 @@ export const extendSequelize = (SequelizeClass: any) => {
         otherAssociationAttributes,
         transaction,
         modelIds,
-        modelPrimaryKey,
       );
 
       !options?.transaction && (await transaction.commit());
@@ -241,7 +239,6 @@ export const extendSequelize = (SequelizeClass: any) => {
         attributes,
         transaction,
         modelId,
-        modelPrimaryKey,
       );
 
       !ops?.transaction && (await transaction.commit());

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -11,6 +11,7 @@ export interface SkillModel
     InferCreationAttributes<SkillModel>
   > {
   id?: CreationOptional<number>;
+  nonDefaultSkillId?: CreationOptional<number>;
   name: string;
   userId?: number;
   user?: Partial<UserModel>;
@@ -24,7 +25,8 @@ export interface UserModel
     InferAttributes<UserModel>,
     InferCreationAttributes<UserModel>
   > {
-  id: CreationOptional<number>;
+  id?: CreationOptional<number>;
+  nonDefaultUserId?: CreationOptional<number>;
   name: string;
   age: number;
   skills?: Array<Partial<SkillModel>>;
@@ -38,7 +40,8 @@ export interface SingleSkillUserModel
     InferAttributes<SingleSkillUserModel>,
     InferCreationAttributes<SingleSkillUserModel>
   > {
-  id: CreationOptional<number>;
+  id?: CreationOptional<number>;
+  nonDefaultUserId?: CreationOptional<number>;
   name: string;
   age: number;
   skill?: Partial<SkillModel> | null;
@@ -49,8 +52,19 @@ export interface UserSkillModel
     InferAttributes<UserSkillModel>,
     InferCreationAttributes<UserSkillModel>
   > {
-  id: CreationOptional<number>;
+  id?: CreationOptional<number>;
+  nonDefaultUserSkillId?: CreationOptional<number>;
   selfGranted: boolean;
   userId: number;
   skillId: number;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    // eslint-disable-next-line
+    interface Matchers <R, T = {}> {
+      toEqualErrors<E = any>(expected: E): R;
+    }
+  }
 }

--- a/tests/update.spec.ts
+++ b/tests/update.spec.ts
@@ -458,7 +458,11 @@ describe("Update", () => {
     const User = sequelize.define<UserModel>(
       "User",
       {
-        nonDefaultUserId: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+        nonDefaultUserId: {
+          type: DataTypes.INTEGER,
+          primaryKey: true,
+          autoIncrement: true,
+        },
         name: DataTypes.STRING,
         age: DataTypes.INTEGER,
       },
@@ -468,7 +472,11 @@ describe("Update", () => {
     const Skill = sequelize.define<SkillModel>(
       "Skill",
       {
-        nonDefaultSkillId: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+        nonDefaultSkillId: {
+          type: DataTypes.INTEGER,
+          primaryKey: true,
+          autoIncrement: true,
+        },
         name: DataTypes.STRING,
         userId: DataTypes.INTEGER,
       },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "outDir": "dist",
     "module": "CommonJS",
     "target": "ES2019",
+    "declaration": true,
     "esModuleInterop": true,
     "strictNullChecks": true,
     "lib": ["ESNext"]


### PR DESCRIPTION
Previously, primary keys that were not "id" might cause failures, and using primary keys that were not the same on both sides of an association did cause failures.  This PR refactors all of the handlers for create, bulk create, and update to allow for primary keys to be any single key.  Composite primary keys are still not supported, but that's not a requirement at the moment.

* Also add transaction to a few queries where it was missing; adding it ensures that all queries run in the correct order and gets pre-commit data.

* Also enable declarations in tsconfig, so consuming apps can use strict typing.